### PR TITLE
Defer validation to runtime for ClojureScript

### DIFF
--- a/src/lambdaisland/uniontypes.cljc
+++ b/src/lambdaisland/uniontypes.cljc
@@ -1,11 +1,8 @@
 (ns lambdaisland.uniontypes
-  (:require [lambdaisland.uniontypes.core :refer [case-of* fix-clojurescript-namespace]]))
+  (:require [lambdaisland.uniontypes.core :refer [case-of*]]
+            [clojure.spec :as s]))
 
 (defmacro case-of [& args]
-  ;; load the referenced namespace, this is mostly for ClojureScript, to load
-  ;; the spec definition at macro expansion time
-  (-> args first namespace symbol require)
-  (let [code (case-of* args)]
-    (if (:ns &env)
-      (fix-clojurescript-namespace code)
-      code)))
+  (let [cljs? (boolean (:ns &env))]
+    (case-of* args cljs?)))
+

--- a/src/lambdaisland/uniontypes.cljc
+++ b/src/lambdaisland/uniontypes.cljc
@@ -1,8 +1,11 @@
 (ns lambdaisland.uniontypes
-  (:require [lambdaisland.uniontypes.core :refer [case-of*]]
+  (:require [lambdaisland.uniontypes.core :refer [case-of*] :as utcore]
             [clojure.spec :as s]))
 
 (defmacro case-of [& args]
   (let [cljs? (boolean (:ns &env))]
     (case-of* args cljs?)))
+
+(s/fdef case-of :args ::utcore/case-of-args)
+
 


### PR DESCRIPTION
Couldn't get this to work at compile time, but having it validate during testing is already a big plus and that works like a charm.

Cleaned up formatting, fixed a few small bugs.

Is there a reason why you have the case-of macro in both namespaces? The way it was, it looked like calls to the main version in lambdaisland.uniontypes weren't spec-checked - fixed (I think).

You've done great work on this, thank you.