### PR TITLE
Add indentation style hint to macro

### DIFF
--- a/src/lambdaisland/uniontypes.cljc
+++ b/src/lambdaisland/uniontypes.cljc
@@ -2,7 +2,9 @@
   (:require [lambdaisland.uniontypes.core :refer [case-of*] :as utcore]
             [clojure.spec :as s]))
 
-(defmacro case-of [& args]
+(defmacro case-of
+  {:style/indent 2}
+  [& args]
   (let [cljs? (boolean (:ns &env))]
     (case-of* args cljs?)))
 


### PR DESCRIPTION
This designates the first two arguments as special (the spec and the value), and the rest as body forms to editors that play by cider's rules: http://cider.readthedocs.io/en/latest/indent_spec/

It's possible something more sophisticated could be applied to the body forms, but this should produce the indentation used in the README.